### PR TITLE
Move methods into class pages for docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -18,11 +18,9 @@
 
    .. rubric:: Attributes
 
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_attributes %}
       {%- if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
+   .. autoattribute:: {{ name }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
    {% endif %}
@@ -33,11 +31,9 @@
 
    .. rubric:: Methods
 
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_methods %}
       {%- if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
 

--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -18,12 +18,10 @@
 
    .. rubric:: Attributes
 
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_attributes %}
       {%- if item not in inherited_members %}
         {%- if not item.startswith('_') %}
-            ~{{ name }}.{{ item }}
+   .. autoattribute:: {{ name }}.{{ item }}
         {%- endif -%}
       {%- endif %}
    {%- endfor %}
@@ -35,12 +33,10 @@
 
    .. rubric:: Methods
 
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_methods %}
       {%- if item not in inherited_members %}
         {%- if not item.startswith('_') %}
-            ~{{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
         {%- endif -%}
       {%- endif %}
    {%- endfor %}

--- a/qiskit_finance/applications/__init__.py
+++ b/qiskit_finance/applications/__init__.py
@@ -19,7 +19,7 @@ Finance applications (:mod:`qiskit_finance.applications`)
 Qiskit Finance ready-made applications.
 
 Optimization Applications
-=========================
+-------------------------
 
 .. autosummary::
    :toctree: ../stubs/
@@ -29,7 +29,7 @@ Optimization Applications
    PortfolioDiversification
 
 Estimation Applications
-=======================
+-----------------------
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit_finance/circuit/__init__.py
+++ b/qiskit_finance/circuit/__init__.py
@@ -12,8 +12,8 @@
 
 
 """
-Circuit library (:mod:`qiskit_finance.circuit`)
-===============================================
+Circuit (:mod:`qiskit_finance.circuit`)
+=======================================
 
 .. currentmodule:: qiskit_finance.circuit
 

--- a/qiskit_finance/circuit/library/__init__.py
+++ b/qiskit_finance/circuit/library/__init__.py
@@ -19,7 +19,7 @@ Circuit Library (:mod:`qiskit_finance.circuit.library`)
 .. currentmodule:: qiskit_finance.circuit.library
 
 Payoff functions
-================
+----------------
 
 .. autosummary::
    :toctree: ../stubs/
@@ -31,7 +31,7 @@ Payoff functions
    FixedIncomePricingObjective
 
 Probability distributions
-=========================
+-------------------------
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit_finance/data_providers/__init__.py
+++ b/qiskit_finance/data_providers/__init__.py
@@ -21,7 +21,7 @@ an external service that sources the actual data; please refer to the
 specific provider class below, for more information in that regard.
 
 Data Provider Base Class
-========================
+------------------------
 
 .. autosummary::
    :toctree: ../stubs/
@@ -30,7 +30,7 @@ Data Provider Base Class
    BaseDataProvider
 
 Data Provider Types
-===================
+-------------------
 
 .. autosummary::
    :toctree: ../stubs/
@@ -39,7 +39,7 @@ Data Provider Types
     StockMarket
 
 Data Providers
-==============
+--------------
 
 .. autosummary::
    :toctree: ../stubs/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Moved all the methods and attributes into class pages to speed up the building process of the documentation with the new ecosystem sphinx theme for consistency with how the other app repo docs is now done e.g. qiskit-community/qiskit-optimization#563

I also updated heading levels in init pages so that only one link appears in the left sidebar for each page (rather than multiple) as was also done in the other app repos.

The init file in .circuit has a title Circuit Library which was the very same as that used in .circuit.library so I removed the library part so that sidebar elements are unique (otherwise it seemed like the same thing and was a bit confusing). Arguably we could link direct to circuit.library at the top level, rather than circuit but I left things as they were for now.

### Details and comments


