### PR TITLE
Update CI to use latest windows

### DIFF
--- a/.github/actions/install-finance/action.yml
+++ b/.github/actions/install-finance/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - run : |
-        if [ "${{ inputs.os }}" == "windows-2019" ]; then
+        if [ "${{ inputs.os }}" == "windows-latest" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi

--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -52,7 +52,7 @@ runs:
       run: |
         if [ "${{ inputs.qiskit-main }}" == "true" ]; then
           echo 'Install Qiskit from Main'
-          if [ "${{ inputs.os }}" == "windows-2019" ]; then
+          if [ "${{ inputs.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -86,7 +86,7 @@ runs:
           fi
         else
           echo 'Install Qiskit from Stable'
-          if [ "${{ inputs.os }}" == "windows-2019" ]; then
+          if [ "${{ inputs.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -96,7 +96,7 @@ runs:
     - name: Install stable Aer
       run: |
         echo 'Install stable Aer'
-        if [ "${{ inputs.os }}" == "windows-2019" ]; then
+        if [ "${{ inputs.os }}" == "windows-latest" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi
@@ -105,7 +105,7 @@ runs:
     - name: Install Optimization from Main
       run: |
         echo 'Install Optimization from Main'
-        if [ "${{ inputs.os }}" == "windows-2019" ]; then
+        if [ "${{ inputs.os }}" == "windows-latest" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -32,7 +32,7 @@ runs:
       env:
         PYTHONWARNINGS: default
       run: |
-        if [ "${{ inputs.os }}" == "windows-2019" ]; then
+        if [ "${{ inputs.os }}" == "windows-latest" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,9 +122,9 @@ jobs:
             python-version: 3.8
           - os: macos-latest
             python-version: 3.11
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
           conda create -y -n scsenv python=${{ matrix.python-version }}
           conda activate scsenv
           conda install -y scs lapack cvxpy -c conda-forge
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
       - uses: ./.github/actions/install-main-dependencies
         with:
@@ -154,7 +154,7 @@ jobs:
           os: ${{ matrix.os }}
       - name: Run lint
         run: |
-          if [ "${{ matrix.os }}" == "windows-2019" ]; then
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -162,7 +162,7 @@ jobs:
         shell: bash
       - name: Run mypy
         run: |
-          if [ "${{ matrix.os }}" == "windows-2019" ]; then
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -179,7 +179,7 @@ jobs:
         if: ${{ !cancelled() }}
       - name: Deprecation Messages
         run: |
-          if [ "${{ matrix.os }}" == "windows-2019" ]; then
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -188,7 +188,7 @@ jobs:
         shell: bash
       - name: Coverage combine
         run: |
-          if [ "${{ matrix.os }}" == "windows-2019" ]; then
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -318,11 +318,11 @@ jobs:
           path: /tmp/m311
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.8
+          name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.10
+          name: windows-latest-3.10
           path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changed windows-2019 to windows-latest (current same as windows-2022) so it running on a newer version and use latest like is done on others. My recollection of it using windows-2019 specifically was when Aer was being built from source. As this is no longer the case it seems better to switch to a newer version and do -latest like is done with Ubuntu and Mac

I already did this in Nature https://github.com/qiskit-community/qiskit-nature/pull/1266 as part of updating CI there.

### Details and comments

The branch rules will need updating to account for the job name change.
