### PR TITLE
Fix Yahoo Data Provider unit test

### DIFF
--- a/test/data_providers/test_data_providers.py
+++ b/test/data_providers/test_data_providers.py
@@ -200,12 +200,15 @@ class TestDataProviders(QiskitFinanceTestCase):
             self.fail(f"Test of ExchangeDataProvider failed: {str(ex)}")
 
     @data(
-        [["MSFT", "AAPL"], [[1349, 476.0], [476.0, 211.0]], [[1.0, 2.99e-05], [2.99e-05, 1.0]]],
-        ["MSFT", 1349.0, [[1.0]]],
+        [["MSFT", "AAPL"], [[1344, 474.0], [474.0, 211.0]], [[1.0, 2.99e-05], [2.99e-05, 1.0]]],
+        ["MSFT", 1344.0, [[1.0]]],
     )
     @unpack
     def test_yahoo(self, tickers, covariance, similarity):
-        """Yahoo data test"""
+        """Yahoo data test."""
+        # Note: Unit test reference values above seem to need updating periodically as the
+        #       data fetched seems to differ slightly presumably due to database being updated and
+        #       maybe historical data compressed or something.
         yahoo = YahooDataProvider(
             tickers=tickers,
             start=datetime.datetime(2021, 1, 1),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

From time to time the yahoo data provider unit test fails as the values fetched no longer match the reference values they were before. Maybe the historical data is compressed occasionally with a single value covering a larger time period so the value is altered a little for the average over that new period. Whatever the reason the nightly CI has failed the last couple of times due to some change in the ref values. This updates them, as had been done in the past, so its not the first time its happened! Since this will break unit tests over in stable I marked it as backport to keep them running if needed.


### Details and comments

I also added a comment in the code to note this since it does need updating periodically.
