### PR TITLE
Fix compatibility/deprecations with newer Qiskit versions

### DIFF
--- a/qiskit_finance/circuit/library/payoff_functions/european_call_pricing_objective.py
+++ b/qiskit_finance/circuit/library/payoff_functions/european_call_pricing_objective.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -54,7 +54,7 @@ class EuropeanCallPricingObjective(QuantumCircuit):
         )
 
         super().__init__(*european_call.qregs, name="ECEV")
-        self._data = european_call.data
+        self.data = european_call.data
         self._european_call = european_call
 
     def post_processing(self, scaled_value: float) -> float:

--- a/qiskit_finance/circuit/library/probability_distributions/lognormal.py
+++ b/qiskit_finance/circuit/library/probability_distributions/lognormal.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2023.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,10 @@
 
 from typing import Tuple, List, Union, Optional
 import numpy as np
+
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import Initialize, Isometry
+
 from .normal import _check_bounds_valid, _check_dimensions_match
 
 
@@ -162,13 +165,10 @@ class LogNormalDistribution(QuantumCircuit):
         super().__init__(*inner.qregs, name=name)
 
         # use default the isometry (or initialize w/o resets) algorithm to construct the circuit
-        # pylint: disable=no-member
         if upto_diag:
-            inner.isometry(np.sqrt(normalized_probabilities), inner.qubits, None)
+            inner.append(Isometry(np.sqrt(normalized_probabilities), 0, 0), inner.qubits)
             self.append(inner.to_instruction(), inner.qubits)  # Isometry is not a Gate
         else:
-            from qiskit.extensions import Initialize  # pylint: disable=cyclic-import
-
             initialize = Initialize(np.sqrt(normalized_probabilities))
             circuit = initialize.gates_to_uncompute().inverse()
             inner.compose(circuit, inplace=True)

--- a/qiskit_finance/circuit/library/probability_distributions/normal.py
+++ b/qiskit_finance/circuit/library/probability_distributions/normal.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2023.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,9 @@
 
 from typing import Tuple, Union, List, Optional, Any
 import numpy as np
+
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import Initialize, Isometry
 
 
 class NormalDistribution(QuantumCircuit):
@@ -208,13 +210,10 @@ class NormalDistribution(QuantumCircuit):
         super().__init__(*inner.qregs, name=name)
 
         # use default the isometry (or initialize w/o resets) algorithm to construct the circuit
-        # pylint: disable=no-member
         if upto_diag:
-            inner.isometry(np.sqrt(normalized_probabilities), inner.qubits, None)
+            inner.append(Isometry(np.sqrt(normalized_probabilities), 0, 0), inner.qubits)
             self.append(inner.to_instruction(), inner.qubits)  # Isometry is not a Gate
         else:
-            from qiskit.extensions import Initialize  # pylint: disable=cyclic-import
-
             initialize = Initialize(np.sqrt(normalized_probabilities))
             circuit = initialize.gates_to_uncompute().inverse()
             inner.compose(circuit, inplace=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.44
+qiskit>=0.45
 qiskit-algorithms>=0.2.0
 qiskit-optimization>=0.6.0
 scipy>=1.4

--- a/test/circuit/test_probability_distributions.py
+++ b/test/circuit/test_probability_distributions.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2023.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,12 +13,12 @@
 """Test library of probability distribution circuits."""
 
 import unittest
-from ddt import ddt, data, unpack
+from test import QiskitFinanceTestCase
 
+from ddt import ddt, data, unpack
 import numpy as np
 from scipy.stats import multivariate_normal
 
-from qiskit.test.base import QiskitTestCase
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector
 from qiskit_finance.circuit.library import (
@@ -28,7 +28,7 @@ from qiskit_finance.circuit.library import (
 )
 
 
-class TestUniformDistribution(QiskitTestCase):
+class TestUniformDistribution(QiskitFinanceTestCase):
     """Test the uniform distribution circuit."""
 
     def test_uniform(self):
@@ -41,7 +41,7 @@ class TestUniformDistribution(QiskitTestCase):
 
 
 @ddt
-class TestNormalDistribution(QiskitTestCase):
+class TestNormalDistribution(QiskitFinanceTestCase):
     """Test the normal distribution circuit."""
 
     def assertDistributionIsCorrect(self, circuit, num_qubits, mu, sigma, bounds, upto_diag):
@@ -146,7 +146,7 @@ class TestNormalDistribution(QiskitTestCase):
 
 
 @ddt
-class TestLogNormalDistribution(QiskitTestCase):
+class TestLogNormalDistribution(QiskitFinanceTestCase):
     """Test the normal distribution circuit."""
 
     def assertDistributionIsCorrect(self, circuit, num_qubits, mu, sigma, bounds, upto_diag):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Nightly CI run failed last night following release of Qiskit 0.46. This PR updates the code around recent deprecations and changes to 0.46 and 1.0

### Details and comments

* setup.py I bumped min version to 0.45 
* Use of qc.isometry has been deprecated so this uses Isometry and appends it
* Initialize moved out of qiskit.extensions (reason to bump min to 0.45)
* One test module inherited from QiskitTestCase and I change this to the local QiskitFinanceTestCase as test is no longer in Qiskit 1.0
* Updated `european call pricing objection` to use public data setter as setting it via _data, while that works up to 0.46, in 1.0 doing that  things no longer worked and threw an error about data.qubits not being there.
