### PR TITLE
Update actions using deprecated Node.js

### DIFF
--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -34,7 +34,7 @@ runs:
       env:
         CACHE_VERSION: v1
       id: qiskit-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: qiskit-cache
         key: qiskit-cache-${{ inputs.os }}-${{ inputs.python-version }}-${{ env.QISKIT_HASH }}-${{ env.CACHE_VERSION }}
@@ -42,7 +42,7 @@ runs:
       env:
         CACHE_VERSION: v1
       id: optimization-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: optimization-cache
         key: optimization-cache-${{ inputs.os }}-${{ inputs.python-version }}-${{ env.OPTIMIZATION_HASH }}-${{ env.CACHE_VERSION }}

--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -27,15 +27,15 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: pip install -U pip setuptools virtualenv wheel
       - name: Build sdist
         run: python3 setup.py sdist bdist_wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
       - name: Deploy to Pypi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,10 +27,10 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ./.github/actions/install-finance

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,10 @@ jobs:
           echo -e "\033[31;1;4mConcurrency Group\033[0m"
           echo -e "$CONCURRENCY_GROUP\n"
         shell: bash
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
       - name: Run upload documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: docs/_build/html/artifacts/documentation.tar.gz
@@ -127,8 +127,8 @@ jobs:
           - os: windows-latest
             python-version: '3.10'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -196,7 +196,7 @@ jobs:
           mv .coverage ./ci-artifact-data/fin.dat
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8 }}
         shell: bash
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
@@ -209,10 +209,10 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.8, 3.11]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -245,7 +245,7 @@ jobs:
           tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
         shell: bash
       - name: Run upload tutorials
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tutorials${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
@@ -275,7 +275,7 @@ jobs:
         if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
         shell: bash
       - name: Run upload stable tutorials
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tutorials-stable${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
@@ -288,39 +288,39 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest-3.8
           path: /tmp/f38
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest-3.9
           path: /tmp/f39
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest-3.10
           path: /tmp/f310
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest-3.11
           path: /tmp/f311
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: macos-latest-3.8
           path: /tmp/m38
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: macos-latest-3.11
           path: /tmp/m311
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.8
           path: /tmp/w38
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.10
           path: /tmp/w310


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently CI - if you look in the build details Summary - has been emitting a bunch of deprecation warnings around actions and Node.js

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This updates the actions to the latest versions.

### Details and comments

I will mark this as stable backport - I think the workflows should backport ok as it has not been long since the last release and it would be better to have them updated as well.

Note: I have updated the actions in the other apps (Nature, ML and Optimimization, as well as Algorithms). I did this manually here for all the actions but intend to add a dependabot config to have it create PRs, when needed in the future for updates. It creates a PR for each action, which is the reason I went ahead and did all actions here as I found out that the upload and download needed to be done together for things to work (it errored finding the file if there was a version mismatch) so I ended up there doing a manual PR anyway to combine the upload and download hence I figured I would have to at least do that here so I may as well do the lot, add the dependabot config afterwards as a separate PR so the updating can have some automation for the future.



