### PR TITLE
Update intersphinx links and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install qiskit-finance
 If you want to work on the very latest work-in-progress versions, either to try features ahead of
 their official release or if you want to contribute to Finance, then you can install from source.
 To do this follow the instructions in the
- [documentation](https://qiskit.org/ecosystem/finance/getting_started.html#installation).
+ [documentation](https://qiskit-community.github.io/qiskit-finance/getting_started.html#installation).
 
 
 ----------------------------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ When running the above the estimated value result should be 2.46 and probability
 ### Further examples
 
 Learning path notebooks may be found in the
-[finance tutorials](https://qiskit.org/ecosystem/finance/tutorials/index.html) section
+[finance tutorials](https://qiskit-community.github.io/qiskit-finance/tutorials/index.html) section
 of the documentation and are a great place to start.
 
 ----------------------------------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,9 +177,9 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "qiskit_algorithms": ("https://qiskit.org/ecosystem/algorithms", None),
-    "qiskit_optimization": ("https://qiskit.org/ecosystem/optimization", None),
-    "qiskit": ("https://qiskit.org/documentation", None),
+    "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
+    "qiskit_optimization": ("https://qiskit-community.github.io/qiskit-optimization", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/docs/tutorials/00_amplitude_estimation.ipynb
+++ b/docs/tutorials/00_amplitude_estimation.ipynb
@@ -24,7 +24,7 @@
     "    \\mathcal{Q} = \\mathcal{A}\\mathcal{S}_0\\mathcal{A}^\\dagger\\mathcal{S}_{\\Psi_1}\n",
     "$$\n",
     "\n",
-    "where $\\mathcal{S}_0$ and $\\mathcal{S}_{\\Psi_1}$ are reflections about the $|0\\rangle$ and $|\\Psi_1\\rangle$ states, respectively, and phase estimation. However this algorithm, called [AmplitudeEstimation](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.AmplitudeEstimation.html) in [Qiskit Algorithms](https://qiskit.org/ecosystem/algorithms/), requires large circuits and is computationally expensive. Therefore, other variants of QAE have been proposed, which we will showcase in this tutorial for a simple example.\n",
+    "where $\\mathcal{S}_0$ and $\\mathcal{S}_{\\Psi_1}$ are reflections about the $|0\\rangle$ and $|\\Psi_1\\rangle$ states, respectively, and phase estimation. However this algorithm, called [AmplitudeEstimation](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.AmplitudeEstimation.html) in [Qiskit Algorithms](https://qiskit-community.github.io/qiskit-algorithms/), requires large circuits and is computationally expensive. Therefore, other variants of QAE have been proposed, which we will showcase in this tutorial for a simple example.\n",
     "\n",
     "In our example, $\\mathcal{A}$ describes a Bernoulli random variable with (assumed to be unknown) success probability $p$:\n",
     "\n",
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Qiskit Algorithms implements several QAE algorithms that all derive from the [AmplitudeEstimator](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.AmplitudeEstimator.html) interface. In the initializer we specify algorithm specific settings and the `estimate` method, which does all the work, takes an [EstimationProblem](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.EstimationProblem.html) as input and returns an [AmplitudeEstimationResult](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.AmplitudeEstimatorResult.html) object. Since all QAE variants follow the same interface, we can use them all to solve the same problem instance. \n",
+    "Qiskit Algorithms implements several QAE algorithms that all derive from the [AmplitudeEstimator](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.AmplitudeEstimator.html) interface. In the initializer we specify algorithm specific settings and the `estimate` method, which does all the work, takes an [EstimationProblem](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.EstimationProblem.html) as input and returns an [AmplitudeEstimationResult](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.AmplitudeEstimatorResult.html) object. Since all QAE variants follow the same interface, we can use them all to solve the same problem instance. \n",
     "\n",
     "Next, we'll run all different QAE algorithms. To do so, we first define the estimation problem which will contain the $\\mathcal{A}$ and $\\mathcal{Q}$ operators as well as how to identify the $|\\Psi_1\\rangle$ state, which in this simple example is just $|1\\rangle$."
    ]

--- a/docs/tutorials/01_portfolio_optimization.ipynb
+++ b/docs/tutorials/01_portfolio_optimization.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "The equality constraint $1^T x = B$ is mapped to a penalty term $(1^T x - B)^2$ which is scaled by a parameter and subtracted from the objective function. \n",
     "The resulting problem can be mapped to a Hamiltonian whose ground state corresponds to  the optimal solution.\n",
-    "This notebook shows how to use the Sampling Variational Quantum Eigensolver (`SamplingVQE`) or the Quantum Approximate Optimization Algorithm (`QAOA`) from [Qiskit Algorithms](https://qiskit.org/ecosystem/algorithms/apidocs/qiskit_algorithms.html#minimum-eigensolvers) to find the optimal solution for a given set of parameters.\n",
+    "This notebook shows how to use the Sampling Variational Quantum Eigensolver (`SamplingVQE`) or the Quantum Approximate Optimization Algorithm (`QAOA`) from [Qiskit Algorithms](https://qiskit-community.github.io/qiskit-algorithms/apidocs/qiskit_algorithms.html#minimum-eigensolvers) to find the optimal solution for a given set of parameters.\n",
     "\n",
     "Experiments on real quantum hardware for this problem are reported for instance in the following paper:\n",
     "<br>\n",

--- a/docs/tutorials/02_portfolio_diversification.ipynb
+++ b/docs/tutorials/02_portfolio_diversification.ipynb
@@ -163,7 +163,7 @@
     "\n",
     "[4] DJ. Berndt and J. Clifford, *Using dynamic time warping to find patterns in time series*. In KDD workshop 1994  (Vol. 10, No. 16, pp. 359-370).\n",
     "\n",
-    "[5] [Max-Cut and Traveling Salesman Problem](https://qiskit.org/ecosystem/optimization/tutorials/06_examples_max_cut_and_tsp.html)"
+    "[5] [Max-Cut and Traveling Salesman Problem](https://qiskit-community.github.io/qiskit-optimization/tutorials/06_examples_max_cut_and_tsp.html)"
    ]
   },
   {

--- a/qiskit_finance/__init__.py
+++ b/qiskit_finance/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,9 +18,9 @@ Qiskit Finance module (:mod:`qiskit_finance`)
 
 This is the Qiskit Finance module. It has applications based on
 `Amplitude Estimation
-<https://qiskit.org/ecosystem/algorithms/apidocs/qiskit_algorithms.html#amplitude-estimators>`__
+<https://qiskit-community.github.io/qiskit-algorithms/apidocs/qiskit_algorithms.html#amplitude-estimators>`__
 and optimization using
-`Qiskit Optimization <https://qiskit.org/ecosystem/optimization/>`__,
+`Qiskit Optimization <https://qiskit-community.github.io/qiskit-optimization/>`__,
 some library circuits useful for finance applications,
 and data providers which supply a source of financial data.
 

--- a/qiskit_finance/data_providers/_base_data_provider.py
+++ b/qiskit_finance/data_providers/_base_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -41,7 +41,7 @@ class BaseDataProvider(ABC):
     Doing so requires that the required driver interface is implemented.
 
     To use the subclasses, please see
-    https://qiskit.org/ecosystem/finance/tutorials/11_time_series.html
+    https://qiskit-community.github.io/qiskit-finance/tutorials/11_time_series.html
 
     """
 

--- a/qiskit_finance/data_providers/data_on_demand_provider.py
+++ b/qiskit_finance/data_providers/data_on_demand_provider.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -30,7 +30,7 @@ class DataOnDemandProvider(BaseDataProvider):
     """NASDAQ Data on Demand data provider.
 
     Please see:
-    https://qiskit.org/ecosystem/finance/tutorials/11_time_series.html
+    https://qiskit-community.github.io/qiskit-finance/tutorials/11_time_series.html
     for instructions on use, which involve obtaining a NASDAQ DOD access token.
     """
 

--- a/qiskit_finance/data_providers/exchange_data_provider.py
+++ b/qiskit_finance/data_providers/exchange_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -27,7 +27,7 @@ class ExchangeDataProvider(BaseDataProvider):
     """Exchange data provider.
 
     Please see:
-    https://qiskit.org/ecosystem/finance/tutorials/11_time_series.html
+    https://qiskit-community.github.io/qiskit-finance/tutorials/11_time_series.html
     for instructions on use, which involve obtaining a Nasdaq Data Link access token.
     """
 

--- a/qiskit_finance/data_providers/wikipedia_data_provider.py
+++ b/qiskit_finance/data_providers/wikipedia_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -27,7 +27,7 @@ class WikipediaDataProvider(BaseDataProvider):
     """Wikipedia data provider.
 
     Please see:
-    https://qiskit.org/ecosystem/finance/tutorials/11_time_series.html
+    https://qiskit-community.github.io/qiskit-finance/tutorials/11_time_series.html
     for instructions on use.
     """
 

--- a/qiskit_finance/data_providers/yahoo_data_provider.py
+++ b/qiskit_finance/data_providers/yahoo_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -36,7 +36,7 @@ class YahooDataProvider(BaseDataProvider):
     """Yahoo data provider.
 
     Please see:
-    https://qiskit.org/ecosystem/finance/tutorials/11_time_series.html
+    https://qiskit-community.github.io/qiskit-finance/tutorials/11_time_series.html
     for instructions on use.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -70,7 +70,7 @@ setuptools.setup(
     python_requires=">=3.8",
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-community/qiskit-finance/issues",
-        "Documentation": "https://qiskit.org/ecosystem/finance/",
+        "Documentation": "https://qiskit-community.github.io/qiskit-finance/",
         "Source Code": "https://github.com/qiskit-community/qiskit-finance",
     },
     zip_safe=False


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #312
Fixes #313

### Details and comments

Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials. I did not alter past release notes. There is a redirect now in effect for the former location on `qiskit.org/ecosystem` so they get to the right place.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.

