### PR TITLE
Fix tutorials to work with Qiskit 1.0

### DIFF
--- a/docs/tutorials/00_amplitude_estimation.ipynb
+++ b/docs/tutorials/00_amplitude_estimation.ipynb
@@ -323,7 +323,7 @@
    "source": [
     "ae_circuit = ae.construct_circuit(problem)\n",
     "ae_circuit.decompose().draw(\n",
-    "    \"mpl\", style=\"iqx\"\n",
+    "    \"mpl\", style=\"clifford\"\n",
     ")  # decompose 1 level: exposes the Phase estimation circuit!"
    ]
   },
@@ -349,7 +349,7 @@
     "\n",
     "\n",
     "basis_gates = [\"h\", \"ry\", \"cry\", \"cx\", \"ccx\", \"p\", \"cp\", \"x\", \"s\", \"sdg\", \"y\", \"t\", \"cz\"]\n",
-    "transpile(ae_circuit, basis_gates=basis_gates, optimization_level=2).draw(\"mpl\", style=\"iqx\")"
+    "transpile(ae_circuit, basis_gates=basis_gates, optimization_level=2).draw(\"mpl\", style=\"clifford\")"
    ]
   },
   {
@@ -413,7 +413,7 @@
    ],
    "source": [
     "iae_circuit = iae.construct_circuit(problem, k=3)\n",
-    "iae_circuit.draw(\"mpl\", style=\"iqx\")"
+    "iae_circuit.draw(\"mpl\", style=\"clifford\")"
    ]
   },
   {
@@ -531,7 +531,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
@@ -547,7 +547,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/tutorials/01_portfolio_optimization.ipynb
+++ b/docs/tutorials/01_portfolio_optimization.ipynb
@@ -400,7 +400,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/02_portfolio_diversification.ipynb
+++ b/docs/tutorials/02_portfolio_diversification.ipynb
@@ -787,7 +787,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/03_european_call_option_pricing.ipynb
+++ b/docs/tutorials/03_european_call_option_pricing.ipynb
@@ -739,7 +739,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/04_european_put_option_pricing.ipynb
+++ b/docs/tutorials/04_european_put_option_pricing.ipynb
@@ -497,7 +497,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/05_bull_spread_pricing.ipynb
+++ b/docs/tutorials/05_bull_spread_pricing.ipynb
@@ -447,7 +447,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/06_basket_option_pricing.ipynb
+++ b/docs/tutorials/06_basket_option_pricing.ipynb
@@ -583,7 +583,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/07_asian_barrier_spread_pricing.ipynb
+++ b/docs/tutorials/07_asian_barrier_spread_pricing.ipynb
@@ -688,7 +688,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/08_fixed_income_pricing.ipynb
+++ b/docs/tutorials/08_fixed_income_pricing.ipynb
@@ -439,7 +439,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/09_credit_risk_analysis.ipynb
+++ b/docs/tutorials/09_credit_risk_analysis.ipynb
@@ -1272,7 +1272,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/10_qgan_option_pricing.ipynb
+++ b/docs/tutorials/10_qgan_option_pricing.ipynb
@@ -344,7 +344,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/11_time_series.ipynb
+++ b/docs/tutorials/11_time_series.ipynb
@@ -536,7 +536,7 @@
     }
    ],
    "source": [
-    "import qiskit.tools.jupyter\n",
+    "import tutorial_magics\n",
     "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"

--- a/docs/tutorials/tutorial_magics.py
+++ b/docs/tutorials/tutorial_magics.py
@@ -1,0 +1,96 @@
+# This code is part of a Qiskit project
+#
+# (C) Copyright IBM 2017, 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=unused-argument
+
+"""A module for version and copyright magics."""
+
+import datetime
+import platform
+import time
+from sys import modules
+
+from IPython import get_ipython
+from IPython.core.magic import line_magic, Magics, magics_class
+from IPython.display import HTML, display
+
+import qiskit
+
+
+@magics_class
+class Copyright(Magics):
+    """A class of status magic functions."""
+
+    @line_magic
+    def qiskit_copyright(self, line="", cell=None):
+        """A Jupyter magic function return qiskit copyright"""
+        now = datetime.datetime.now()
+
+        html = "<div style='width: 100%; background-color:#d5d9e0;"
+        html += "padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'>"
+        html += "<h3>This code is a part of a Qiskit project</h3>"
+        html += "<p>&copy; Copyright IBM 2017, %s.</p>" % now.year
+        html += "<p>This code is licensed under the Apache License, Version 2.0. You may<br>"
+        html += "obtain a copy of this license in the LICENSE.txt file in the root directory<br> "
+        html += "of this source tree or at http://www.apache.org/licenses/LICENSE-2.0."
+
+        html += "<p>Any modifications or derivative works of this code must retain this<br>"
+        html += "copyright notice, and modified files need to carry a notice indicating<br>"
+        html += "that they have been altered from the originals.</p>"
+        html += "</div>"
+        return display(HTML(html))
+
+
+@magics_class
+class VersionTable(Magics):
+    """A class of status magic functions."""
+
+    @line_magic
+    def qiskit_version_table(self, line="", cell=None):
+        """
+        Print an HTML-formatted table with version numbers for Qiskit and its
+        dependencies. This should make it possible to reproduce the environment
+        and the calculation later on.
+        """
+        html = "<h3>Version Information</h3>"
+        html += "<table>"
+        html += "<tr><th>Software</th><th>Version</th></tr>"
+
+        packages = {"qiskit": qiskit.__version__}
+        qiskit_modules = {module.split(".")[0] for module in modules.keys() if "qiskit" in module}
+
+        for qiskit_module in qiskit_modules:
+            packages[qiskit_module] = getattr(modules[qiskit_module], "__version__", None)
+
+        for name, version in packages.items():
+            if version:
+                html += f"<tr><td><code>{name}</code></td><td>{version}</td></tr>"
+
+        html += "<tr><th colspan='2'>System information</th></tr>"
+
+        sys_info = [
+            ("Python version", platform.python_version()),
+            ("OS", "%s" % platform.system()),
+        ]
+
+        for name, version in sys_info:
+            html += f"<tr><td>{name}</td><td>{version}</td></tr>"
+
+        html += "<tr><td colspan='2'>%s</td></tr>" % time.strftime("%a %b %d %H:%M:%S %Y %Z")
+        html += "</table>"
+
+        return display(HTML(html))
+
+
+_IP = get_ipython()
+if _IP is not None:
+    _IP.register_magics(VersionTable)
+    _IP.register_magics(Copyright)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit 1,0 removed the deprecated qiskit.tools which included some .jupyter from which the magics that did the version and copyright were imported. This PR adds a local file in the tutorials folder that contains just these magics and changes the import to use this.

Similar fix to qiskit-community/qiskit-algorithms#156

### Details and comments


