### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -127,6 +127,7 @@ runs:
         if [ "$build_from_main" == "true" ]; then
           echo 'Create wheel file from main'
           pip install -U wheel
+          pip install -U setuptools
           git clone --depth 1 --branch main https://github.com/qiskit-community/qiskit-optimization.git /tmp/qiskit-optimization
           pushd /tmp/qiskit-optimization
           python setup.py bdist_wheel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -116,16 +116,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.12
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: '3.10'
+            python-version: 3.11
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -207,7 +207,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -310,11 +310,15 @@ jobs:
           path: /tmp/f311
       - uses: actions/download-artifact@v4
         with:
+          name: ubuntu-latest-3.12
+          path: /tmp/f312
+      - uses: actions/download-artifact@v4
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.11
+          name: macos-latest-3.12
           path: /tmp/m311
       - uses: actions/download-artifact@v4
         with:
@@ -322,14 +326,14 @@ jobs:
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.10
+          name: windows-latest-3.11
           path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/f38/fin.dep /tmp/f39/fin.dep /tmp/f310/fin.dep /tmp/f311/fin.dep /tmp/m38/fin.dep /tmp/m311/fin.dep /tmp/w38/fin.dep /tmp/w310/fin.dep || true
+          sort -f -u /tmp/f38/fin.dep /tmp/f39/fin.dep /tmp/f310/fin.dep /tmp/f311/fin.dep /tmp/f312/fin.dep /tmp/m38/fin.dep /tmp/m312/fin.dep /tmp/w38/fin.dep /tmp/w311/fin.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/f38/fin.dat

--- a/releasenotes/notes/py_3_12_support-b61ebb772bc24cb8.yaml
+++ b/releasenotes/notes/py_3_12_support-b61ebb772bc24cb8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for using Qiskit Finance with Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering"
     ],
     keywords='qiskit sdk quantum finance',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, py312, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #316

I marked this stable backport in order to facilitate a release that supports 3.12.

FYI: PR for Optimzation that adds the 3.12 support there qiskit-community/qiskit-optimization#580

### Details and comments

Branch rules will need updating for this change.

Similar to #263 which added support for 3.11 where the Windows upper Python version needed to be restricted I have done the same here as `cvxpy` only has pre-built wheels for 3.11 and while Ubuntu and Mac are set for 3.12 this is because CI can build the wheels ok (as it does in Optimization) but that does not happen for Windows.



