### PR TITLE
Remove `psutil` from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ qiskit-algorithms>=0.2.0
 qiskit-optimization>=0.6.0
 scipy>=1.4
 numpy>=1.17
-psutil>=5
 fastdtw
 setuptools>=40.1.0
 pandas


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`psutil` is not, and never was, used by this package. No need to keep it around.

### Details and comments

Exactly the same as in https://github.com/qiskit-community/qiskit-machine-learning/pull/894

