### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "qiskit_algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
     "qiskit_optimization": ("https://qiskit-community.github.io/qiskit-optimization", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Installation
 ============
 
 Qiskit Finance depends on Qiskit, which has its own
-`installation instructions <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options and its supported environments/platforms. You should refer to
 that first. Then the information here can be followed which focuses on the additional installation
 specific to Qiskit Finance.
@@ -17,7 +17,7 @@ specific to Qiskit Finance.
 
     .. tab-item:: Start locally
 
-        The simplest way to get started is to follow the installation guide for Qiskit `here <https://docs.quantum.ibm.com/start/install>`__
+        The simplest way to get started is to follow the installation guide for Qiskit `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__
 
         In your virtual environment, where you installed Qiskit, install ``qiskit-finance`` as follows:
 
@@ -40,7 +40,7 @@ specific to Qiskit Finance.
 
        Since Qiskit Finance depends on Qiskit, and its latest changes may require new or changed
        features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions
-       `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+       `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source>`__
 
        .. raw:: html
 


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.