### PR TITLE
Fix minor typo in docstring

### DIFF
--- a/test/circuit/test_probability_distributions.py
+++ b/test/circuit/test_probability_distributions.py
@@ -147,10 +147,10 @@ class TestNormalDistribution(QiskitFinanceTestCase):
 
 @ddt
 class TestLogNormalDistribution(QiskitFinanceTestCase):
-    """Test the normal distribution circuit."""
+    """Test the log-normal distribution circuit."""
 
     def assertDistributionIsCorrect(self, circuit, num_qubits, mu, sigma, bounds, upto_diag):
-        """Assert that ``circuit`` implements the normal distribution correctly.
+        """Assert that ``circuit`` implements the log-normal distribution correctly.
 
         This test asserts that the ``circuit`` produces the desired state-vector.
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix minor typo. 
Under the `TestLogNormalDistribution`, I modified the typo from "normal distribution" to "log-normal distribution"



